### PR TITLE
Python 3 trips over local imports

### DIFF
--- a/slackcat/__main__.py
+++ b/slackcat/__main__.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 from __future__ import print_function
+from __future__ import absolute_import
 
 import argparse
 import sys
 
-import slack
-from ioutil import Stream
+from . import slack
+from .ioutil import Stream
 
 
 def main():

--- a/slackcat/compat.py
+++ b/slackcat/compat.py
@@ -6,7 +6,15 @@ try:
     # Python 3.x
     from urllib.parse import urlencode
     import urllib.request as urlrequest
+
+    def encode(s, decode='unicode_escape', encode='utf-8'):
+        return s
+
 except ImportError:
     # Python 2.x
     from urllib import urlencode  # noqa
     import urllib2 as urlrequest  # noqa
+
+    def encode(s, decode='unicode_escape', encode='utf-8'):
+        return s.decode(decode).encode(encode)
+

--- a/slackcat/compat.py
+++ b/slackcat/compat.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
 
 try:
     # Python 3.x

--- a/slackcat/slack.py
+++ b/slackcat/slack.py
@@ -7,6 +7,7 @@ import json
 from . import config
 from .compat import urlencode
 from .compat import urlrequest
+from .compat import encode
 from .exceptions import APIError
 
 
@@ -20,10 +21,6 @@ def send_message(channel, message, username=None, icon_url=None):
             'text': text,
         },
     )
-
-
-def encode(s, decode='unicode_escape', encode='utf-8'):
-    return s.decode(decode).encode(encode)
 
 
 def _request(url, payload):

--- a/slackcat/slack.py
+++ b/slackcat/slack.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import json
 
-import config
-from compat import urlencode
-from compat import urlrequest
-from exceptions import APIError
+from . import config
+from .compat import urlencode
+from .compat import urlrequest
+from .exceptions import APIError
 
 
 def send_message(channel, message, username=None, icon_url=None):


### PR DESCRIPTION
Python 2 is happy with the local import, Python 3 isn't because it's expecting an absolute import:

```
Traceback (most recent call last):
  File "/Users/sdehaan/.virtualenvs/slackcat/bin/slackcat", line 11, in <module>
    load_entry_point('slackcat', 'console_scripts', 'slackcat')()
  File "/Users/sdehaan/.virtualenvs/slackcat/lib/python3.6/site-packages/pkg_resources/__init__.py", line 476, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/Users/sdehaan/.virtualenvs/slackcat/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2700, in load_entry_point
    return ep.load()
  File "/Users/sdehaan/.virtualenvs/slackcat/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2318, in load
    return self.resolve()
  File "/Users/sdehaan/.virtualenvs/slackcat/lib/python3.6/site-packages/pkg_resources/__init__.py", line 2324, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/Users/sdehaan/Repositories/slackcat/slackcat/__main__.py", line 8, in <module>
    import slack
ModuleNotFoundError: No module named 'slack'
```

This change fixes it for both.